### PR TITLE
3 lytix planner use core external

### DIFF
--- a/classes/planner_event_lib.php
+++ b/classes/planner_event_lib.php
@@ -28,6 +28,8 @@
 
 namespace lytix_planner;
 
+defined('MOODLE_INTERNAL') || die();
+
 global $CFG;
 require_once("{$CFG->libdir}/externallib.php");
 

--- a/classes/planner_event_lib.php
+++ b/classes/planner_event_lib.php
@@ -28,14 +28,15 @@
 
 namespace lytix_planner;
 
-use external_api;
+global $CFG;
+require_once("{$CFG->libdir}/externallib.php");
+
 use lytix_logs\logger;
-use lytix_planner\dynamic_events;
 
 /**
  * Class planner_event_lib
  */
-class planner_event_lib extends external_api {
+class planner_event_lib extends \external_api {
     /**
      * Checks planner event parameters.
      *

--- a/classes/planner_get.php
+++ b/classes/planner_get.php
@@ -28,12 +28,13 @@
 
 namespace lytix_planner;
 
-use external_api;
+global $CFG;
+require_once("{$CFG->libdir}/externallib.php");
 
 /**
  * Class planner_get
  */
-class planner_get extends external_api {
+class planner_get extends \external_api {
     /**
      * Checks parameters.
      *

--- a/classes/planner_get.php
+++ b/classes/planner_get.php
@@ -28,6 +28,8 @@
 
 namespace lytix_planner;
 
+defined('MOODLE_INTERNAL') || die();
+
 global $CFG;
 require_once("{$CFG->libdir}/externallib.php");
 

--- a/classes/planner_milestone_lib.php
+++ b/classes/planner_milestone_lib.php
@@ -28,6 +28,9 @@
 
 namespace lytix_planner;
 
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
 require_once("{$CFG->libdir}/externallib.php");
 
 use lytix_logs\logger;

--- a/classes/planner_milestone_lib.php
+++ b/classes/planner_milestone_lib.php
@@ -28,13 +28,14 @@
 
 namespace lytix_planner;
 
-use external_api;
+require_once("{$CFG->libdir}/externallib.php");
+
 use lytix_logs\logger;
 
 /**
  * Class planner_milestone_lib
  */
-class planner_milestone_lib extends external_api {
+class planner_milestone_lib extends \external_api {
     /**
      * Checks parameters.
      * @return \external_function_parameters

--- a/classes/planner_notifications_lib.php
+++ b/classes/planner_notifications_lib.php
@@ -28,14 +28,12 @@
 
 namespace lytix_planner;
 
-use external_api;
-use lytix_logs\logger;
-use lytix_planner\notification_settings;
+require_once("{$CFG->libdir}/externallib.php");
 
 /**
  * Class planner_notifications_lib
  */
-class planner_notifications_lib extends external_api {
+class planner_notifications_lib extends \external_api {
 
     /**
      * Checks course notification settings parameters.

--- a/classes/planner_notifications_lib.php
+++ b/classes/planner_notifications_lib.php
@@ -28,6 +28,9 @@
 
 namespace lytix_planner;
 
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
 require_once("{$CFG->libdir}/externallib.php");
 
 /**

--- a/tests/planner_get_test.php
+++ b/tests/planner_get_test.php
@@ -29,7 +29,6 @@ defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once("{$CFG->dirroot}/webservice/tests/helpers.php");
-require_once("{$CFG->libdir}/externallib.php");
 
 use external_api;
 use externallib_advanced_testcase;

--- a/tests/planner_get_test.php
+++ b/tests/planner_get_test.php
@@ -27,12 +27,14 @@ namespace lytix_planner;
 
 defined('MOODLE_INTERNAL') || die();
 
+global $CFG;
+require_once("{$CFG->dirroot}/webservice/tests/helpers.php");
+require_once("{$CFG->libdir}/externallib.php");
+
 use external_api;
 use externallib_advanced_testcase;
 use lytix_helper\dummy;
 
-global $CFG;
-require_once("{$CFG->dirroot}/webservice/tests/helpers.php");
 
 /**
  * Class planner_get_test

--- a/tests/planner_notifications_lib_test.php
+++ b/tests/planner_notifications_lib_test.php
@@ -55,13 +55,6 @@ class planner_notifications_lib_test extends externallib_advanced_testcase {
     private $context = null;
 
     /**
-     * Variable for the coursesettings
-     *
-     * @var \stdClass|null
-     */
-    private $crssettings = null;
-
-    /**
      * Setup called before any test case.
      */
     public function setUp(): void {
@@ -69,7 +62,6 @@ class planner_notifications_lib_test extends externallib_advanced_testcase {
         $this->setAdminUser();
         global $CFG;
         require_once("{$CFG->libdir}/externallib.php");
-
 
         $this->course = $this->getDataGenerator()->create_course();
         $this->context  = \context_course::instance($this->course->id);
@@ -82,7 +74,7 @@ class planner_notifications_lib_test extends externallib_advanced_testcase {
         set_config('course_list', $this->course->id, 'local_lytix');
         set_config('platform', 'learners_corner', 'local_lytix');
 
-        $this->crssettings = notification_settings::test_and_set_course($this->course->id);
+        notification_settings::test_and_set_course($this->course->id);
     }
 
     /**

--- a/tests/planner_notifications_lib_test.php
+++ b/tests/planner_notifications_lib_test.php
@@ -29,7 +29,6 @@ defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once("{$CFG->dirroot}/webservice/tests/helpers.php");
-require_once("{$CFG->libdir}/externallib.php");
 
 use external_api;
 use externallib_advanced_testcase;
@@ -68,6 +67,9 @@ class planner_notifications_lib_test extends externallib_advanced_testcase {
     public function setUp(): void {
         $this->resetAfterTest(true);
         $this->setAdminUser();
+        global $CFG;
+        require_once("{$CFG->libdir}/externallib.php");
+
 
         $this->course = $this->getDataGenerator()->create_course();
         $this->context  = \context_course::instance($this->course->id);

--- a/tests/planner_notifications_lib_test.php
+++ b/tests/planner_notifications_lib_test.php
@@ -29,6 +29,7 @@ defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once("{$CFG->dirroot}/webservice/tests/helpers.php");
+require_once("{$CFG->libdir}/externallib.php");
 
 use external_api;
 use externallib_advanced_testcase;
@@ -67,8 +68,6 @@ class planner_notifications_lib_test extends externallib_advanced_testcase {
     public function setUp(): void {
         $this->resetAfterTest(true);
         $this->setAdminUser();
-        global $CFG;
-        require_once("{$CFG->libdir}/externallib.php");
 
         $this->course = $this->getDataGenerator()->create_course();
         $this->context  = \context_course::instance($this->course->id);

--- a/version.php
+++ b/version.php
@@ -32,6 +32,6 @@ $plugin->dependencies = [
     'lytix_logs' => ANY_VERSION,
     'lytix_helper' => ANY_VERSION,
 ];
-$plugin->release   = 'v1.0.8';
+$plugin->release   = 'v1.0.9';
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->supported = [401, 403];


### PR DESCRIPTION
Change the import of externallib to work for both Moodle 4.1 and 4.2+.
Change the import to work for Moodle 4.2 and The Testmatrix for Moodle 4.2